### PR TITLE
Fixes issue when quick incr/decr calls mess up response parsing

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -90,12 +90,14 @@ Client.config = {
       , memcached = this;
     
     serverTokens.pop();
-    
+
+    var sid = 0;
     this.connections[server] = new Manager(server, this.poolSize, function(callback){
       var S = new Stream
         , Manager = this;
       
       // config the Stream
+      S.streamID = sid++;
       S.setTimeout(memcached.timeout);
       S.setNoDelay(true);
       S.metaData = [];
@@ -172,10 +174,11 @@ Client.config = {
     
     // check if the server is still alive
     if (server in this.issues && this.issues[server].failed) return query.callback && query.callback(false, false);
-    
-    Client.config.debug && console.log(query.command);
-    
+
     this.connect(server, function allocateMemcachedConnection(error, S){
+      if (Client.config.debug)
+        query.command.split(LINEBREAK).forEach(function(line) { console.log(S.streamID + ' \033[34m<<\033[0m ' + line); });
+
       // check for issues
       if (!S) return query.callback && query.callback(false, false);
       if (error) return query.callback && query.callback(error);
@@ -401,13 +404,14 @@ Client.config = {
   // because that is all what is sure about the Memcached Protocol, all responds end with them.
   private.buffer = function BufferBuffer(S, BufferStream){
     S.responseBuffer += BufferStream;
-    
-    Client.config.debug && console.log(S.responseBuffer);
-    
+
     // only call transform the data once we are sure, 100% sure, that we valid response ending
     if (S.responseBuffer.substr(S.responseBuffer.length - 2) === LINEBREAK){
       var chunks = S.responseBuffer.split(LINEBREAK);
-      
+
+      if (Client.config.debug)
+        chunks.forEach(function(line) { console.log(S.streamID + ' \033[35m>>\033[0m ' + line); });
+
       S.responseBuffer = ""; // clear!
       this.rawDataReceived(S, S.bufferArray = S.bufferArray.concat(chunks));
     } 


### PR DESCRIPTION
Hey 3rd-Eden,

nice chatting with you today on #node.js. I've promised I'll find bugs for you, and here's the first one I've found. When I was incrementing and decrementing multiple keys in parallel the response parsing got messed up because it consumed incr/decr responses when parsing other responses. I've fixed the issue by adding a conditional to only try to fetch response content for VALUE reponses.

There's also a commit wich adds better debug output for commands and responses.

Best,
LacKac
