### PR TITLE
Fix for issue #6. May not be correct implementation, but causes an issue

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -112,7 +112,7 @@ Client.config = {
       , close: function streamClose(){ Manager.remove(this) }
       , error: function streamError(err){ memcached.connectionIssue(err, S, callback) }
       , data: Utils.curry(memcached, private.buffer, S)
-      , timeout: function streamTimeout(){ Manager.remove(this) }
+      , timeout: function streamTimeout(){ memcached.connectionIssue('timeout', S, callback) }
       , end: S.end
       });
       


### PR DESCRIPTION
to be raised when the Stream library times out (instead of waiting for
an error). Treats a Stream connection timeout as an error.
