### PR TITLE
Add flush_all as an alias of flush

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -721,7 +721,7 @@ Client.config = {
   // Curry the function and so we can tell the type our private singles
   memcached.version = Utils.curry(false, private.singles, 'version');
   memcached.flush = Utils.curry(false, private.singles, 'flush_all');
-  memcached.flush_all = memcached.flush;
+  memcached.flushAll = memcached.flush;
   memcached.stats = Utils.curry(false, private.singles, 'stats');
   memcached.settings = Utils.curry(false, private.singles, 'stats settings');
   memcached.slabs = Utils.curry(false, private.singles, 'stats slabs');


### PR DESCRIPTION
Intuitively I was expecting a method named `flush_all` since all other memcached protocol commands have their corresponding methods that are named the same way.

Maybe you want to add that method? Alternatively documentation in the readme could help to make things clear.
