### PR TITLE
memcached alias name bug

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -361,11 +361,15 @@ Client.config = {
     }
   };
 
+  function resultSetIsEmpty(resultSet) {
+    return !resultSet || (resultSet.length == 1 && !resultSet[0]);
+  }
   // Parses down result sets
   private.resultParsers = {
     // combines the stats array, in to an object
     'stats': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;
@@ -383,6 +387,7 @@ Client.config = {
     // Group slabs by slab id
   , 'stats slabs': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;
@@ -399,6 +404,7 @@ Client.config = {
     }
   , 'stats items': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;


### PR DESCRIPTION
Aliases appended near the end of the file where reversed and overwritten with "undefined"s.  Also inserted common formatting for both sections.

Aliases not overwritten anymore:
- stats by statsSettings
- slabs by statsSlabs
- items by statsItems
