### PR TITLE
Response is "[false]", return early

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -361,11 +361,15 @@ Client.config = {
     }
   };
 
+  function resultSetIsEmpty(resultSet) {
+    return !resultSet || (resultSet.length == 1 && !resultSet[0]);
+  }
   // Parses down result sets
   private.resultParsers = {
     // combines the stats array, in to an object
     'stats': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;
@@ -383,6 +387,7 @@ Client.config = {
     // Group slabs by slab id
   , 'stats slabs': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;
@@ -399,6 +404,7 @@ Client.config = {
     }
   , 'stats items': function(resultSet){
       var response = {};
+      if (resultSetIsEmpty(resultSet)) return response;
 
       // add references to the retrieved server
       response.server = this.serverAddress;


### PR DESCRIPTION
According to the docs, 'false' is an invalid or empty response.  

The resultsSet object is depending on containing array tuples of information.  This doesn't work with boolean 'false' where the array should be.  

I'm currently running on one memcached node that is completely fresh.  I might expect this is not the optimal solution to work with multiple nodes, but I believe a check should be made.

Best,
Barret
