### PR TITLE
return null for error in callback

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -574,12 +574,15 @@ Client.config = {
   memcached.getMulti = function getMulti(keys, callback){
     var memcached = this
       , responses = {}
-      , errors = []
+      , errors = null
       , calls
 
       // handle multiple responses and cache them untill we receive all.
       , handle = function(err, results){
-          if (err) errors.push(err);
+          if (err) {
+            errors || (errors = []);
+            errors.push(err);
+          }
 
           // add all responses to the array
           (Array.isArray(results) ? results : [results]).forEach(function(value){ Utils.merge(responses, value) });
@@ -693,12 +696,15 @@ Client.config = {
   private.singles = function singles(type, callback){
     var memcached = this
       , responses = []
-      , errors = []
+      , errors = null
       , calls
 
       // handle multiple servers
       , handle = function(err, results){
-        if (err) errors.push(err);
+        if (err) {
+          errors || (errors = []);
+          errors.push(err);
+        }
         if (results) responses = responses.concat(results);
 
         // multi calls should ALWAYS return an array!


### PR DESCRIPTION
The paradigm for node.js callbacks is to return a 'null' object if no errors are found for the error value.

This allows for quick 

```
if (responseError) fix_it();
```

Best,
Barret
