### PR TITLE
fix for #31

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -179,7 +179,7 @@ Client.config = {
       , memcached = this;
 
     // validate the arguments
-    if (query.validation && !Utils.validateArg(query, this)) return;
+    if (query.validate && !Utils.validateArg(query, this)) return;
 
     // try to find the correct server for this query
     if (!server) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,7 +38,7 @@ exports.validateArg = function validateArg(args, config){
             args[key] = CreateHash('md5').update(value).digest('hex');
             
             // also make sure you update the command
-            config.command.replace(new RegExp('^(' + value + ')'), args[key]); 
+            args.command.replace(new RegExp('^(' + value + ')'), args[key]); 
           } else {
             err = 'Argument "' + key + '" is longer than the maximum allowed length of ' + config.maxKeySize;
           }


### PR DESCRIPTION
Quick fix that enables back validation for queryBuilder.

Additionally hashing keys that are too long is working again.
