### PR TITLE
Updated invalid test for binary files

### DIFF
--- a/tests/memcached-get-set.test.js
+++ b/tests/memcached-get-set.test.js
@@ -287,7 +287,7 @@ module.exports = {
         ++callbacks;
         
         assert.ok(!error);
-        assert.ok(answer.toString('binary') === answer.toString('binary'));
+        assert.ok(answer.toString('binary') === message.toString('binary'));
         memcached.end(); // close connections
       });
     });


### PR DESCRIPTION
The assertion was testing answer === answer instead
of checking the original message.

Binary files are getting changed between set and get.  The 
assertion in the tests was not checking this.
