### PR TITLE
Support for Unix sockets

### DIFF
--- a/examples/memcached_connect_socket.js
+++ b/examples/memcached_connect_socket.js
@@ -1,0 +1,5 @@
+var nMemcached = require( '../' ),
+	memcached;
+
+// connect to our memcached server listening on Unix socket /tmp/.memcached.sock
+memcached = new nMemcached( '/tmp/.memcached.sock' );

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter
   , Stream = require('net').Stream
+  , Socket = require('net').Socket
   , Buffer = require('buffer').Buffer;
 
 var HashRing = require('hashring')
@@ -94,14 +95,15 @@ Client.config = {
     if (server in this.connections) return this.connections[server].allocate(callback);
 
     // No connection factory created yet, so we must build one
-    var serverTokens = /(.*):(\d+){1,}$/.exec(server).reverse()
+    var serverTokens = server[0] === '/' ? server : /(.*):(\d+){1,}$/.exec(server).reverse()
       , memcached = this;
 
-    serverTokens.pop();
+    // Pop original string from array
+    if (Array.isArray(serverTokens)) serverTokens.pop();
 
     var sid = 0;
     this.connections[server] = new Manager(server, this.poolSize, function(callback){
-      var S = new Stream
+      var S = Array.isArray(serverTokens) ? new Stream : new Socket
         , Manager = this;
 
       // config the Stream
@@ -112,7 +114,7 @@ Client.config = {
       S.responseBuffer = "";
       S.bufferArray = [];
       S.serverAddress = server;
-      S.tokens = serverTokens;
+      S.tokens = [].concat(serverTokens);
       S.memcached = memcached;
 
       // Add the event listeners
@@ -125,8 +127,8 @@ Client.config = {
       , end: S.end
       });
 
-      // connect the net.Stream [port, hostname]
-      S.connect.apply(S, serverTokens);
+      // connect the net.Stream (or net.Socket) [port, hostname]
+      S.connect.apply(S, S.tokens);
       return S;
     });
 


### PR DESCRIPTION
Added support for Unix sockets by checking if server location begins with a slash (/). If so, a net.Socket is opened instead of a net.Stream.

Additionally, a simple example is included.
