### PR TITLE
If the whole connection pool is busy, return error.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -132,10 +132,7 @@ Manager.allocate = function allocate (callback) {
     return this.connections.push(this.factory.apply(this, arguments));
   }
 
-  // wait untill the next event loop tick, to try again
-  process.nextTick(function next () {
-    Manager.allocate(callback);
-  });
+  callback(new Error("All the connections in the memcached pool are busy"));
 };
 
 Manager.isAvailable = function isAvailable (connection) {


### PR DESCRIPTION
This way, the user can decide whether to reschedule or drop the request. Fixes #43.
