### PR TITLE
Added error messages to replace the false argument in 2 query callbacks on server error

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -245,7 +245,7 @@ Client.config = {
 
     // check if the server is still alive
     if (server in this.issues && this.issues[server].failed) {
-      return query.callback && query.callback('Server not available', false);
+      return query.callback && query.callback('Server not available');
     }
 
     this.connect(server, function allocateMemcachedConnection (error, S) {
@@ -258,7 +258,7 @@ Client.config = {
       // check for issues
       if (error) return query.callback && query.callback(error);
 
-      if (!S) return query.callback && query.callback('Connect did not give a server', false);
+      if (!S) return query.callback && query.callback('Connect did not give a server');
 
       if (S.readyState !== 'open') {
         return query.callback && query.callback('Connection readyState is set to ' + S.readySate);


### PR DESCRIPTION
As we discussed on IRC, we want all errors to yield a truthy error argument in the callback. Arguably, these should change to Error instances, but for the two I added I stuck with the current way of yielding errors (simple strings).
