### PR TITLE
Exposes raw memcache response for empty values

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -404,12 +404,21 @@ Client.config = {
   , 'VALUE': function value(tokens, dataSet, err, queue) {
       var key = tokens[1]
         , flag = +tokens[2]
-        , expire = tokens[3]
+        , dataLen = tokens[3] // length of dataSet in raw bytes
         , cas = tokens[4]
         , multi = this.metaData[0] && this.metaData[0].multi || cas
           ? {}
           : false
         , tmp;
+
+      // In parse data there is an '||' passing us the content of token
+      // if dataSet is empty. This may be fine for other types of responses,
+      // in the case of an empty string being stored in a key, it will
+      // result in unexpected behavior:
+      // https://github.com/3rd-Eden/node-memcached/issues/64
+      if (dataLen === '0') {
+        dataSet = '';
+      }
 
       switch (flag) {
         case FLAG_JSON:

--- a/package.json
+++ b/package.json
@@ -41,4 +41,7 @@
         "mocha": "*"
       , "should": "*"
     }
+  , "scripts": {
+      "test": "./node_modules/.bin/mocha tests/"
+    }
 }

--- a/tests/common.js
+++ b/tests/common.js
@@ -1,14 +1,27 @@
+
+/**
+ * Make should available in all test cases.
+ */
+var should = require('should');
+
 /**
  * Server ip addresses that get used during the tests
  * NOTE! Make sure you configure empty servers as they
  * will get flushed!.
+ * 
+ * If your memcache hosts is not the default one
+ * (10.211.55.5), you can pass another one using the
+ * environment variable MEMCACHED__HOST. E.g.:
+ * 
+ * MEMCACHED__HOST=localhost npm test
  *
  * @type {Object}
  * @api public
  */
+var testMemcachedHost = process.env['MEMCACHED__HOST'] || '10.211.55.5';
 exports.servers = {
-  single: '10.211.55.5:11211'
-, multi: ['10.211.55.5:11211', '10.211.55.5:11212', '10.211.55.5:11213']
+  single: testMemcachedHost + ':11211'
+, multi: [testMemcachedHost + ':11211', testMemcachedHost + ':11212', testMemcachedHost + ':11213']
 };
 
 /**

--- a/tests/memcached-get-set.test.js
+++ b/tests/memcached-get-set.test.js
@@ -47,6 +47,33 @@ describe("Memcached GET SET", function() {
       });
   });
 
+  it("set and get an empty string", function(done) {
+    var memcached = new Memcached(common.servers.single)
+        , testnr = ++global.testnumbers
+        , callbacks = 0;
+
+      memcached.set("test:" + testnr, "", 1000, function(error, ok){
+        ++callbacks;
+
+        assert.ok(!error);
+        ok.should.be.true;
+
+        memcached.get("test:" + testnr, function(error, answer){
+          ++callbacks;
+
+          assert.ok(!error);
+
+          assert.ok(typeof answer === 'string');
+          answer.should.eql("");
+
+          memcached.end(); // close connections
+          assert.equal(callbacks, 2);
+          done();
+
+        });
+      });
+  });
+
   /**
    * Set a stringified JSON object, and make sure we only return a string
    * this should not be flagged as JSON object


### PR DESCRIPTION
Added test case and fix for setting and getting empty strings

Since I wasn't completely sure if some other parts of the code may be relying on the token-line being passed instead of the data-section whenever the data-section was empty/not present, I tried to keep the fix as local as possible.

This pull request also includes the possibility to run the test suite using `npm test` and to run the test suite with a custom memcached-server via `MEMCACHED__HOST=localhost npm test`. Including the "require('should')"-line was necessary for me to get the tests running. Otherwise ok.should was always null.

If you only want to have the actual fix, ignore everything but the four lines in `lib/memcached.js`.

This pull request refers to: https://github.com/3rd-Eden/node-memcached/issues/64
