### PR TITLE
Fix for issue with values starting with OK, VALUE etc.

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -590,7 +590,7 @@ Client.config = {
     var queue = []
       , token
       , tokenSet
-      , dataSet = ''
+      , dataSet
       , resultSet
       , metaData
       , err = []
@@ -615,11 +615,7 @@ Client.config = {
 
         // fetch the response content
         if (tokenSet[0] === 'VALUE') {
-          while (S.bufferArray.length) {
-            if (privates.bufferedCommands.test(S.bufferArray[0])) break;
-
-            dataSet += S.bufferArray.shift();
-          }
+          dataSet = Utils.unescapeValue(S.bufferArray.shift());
         }
 
         resultSet = privates.parsers[tokenSet[0]].call(S, tokenSet, dataSet || token, err, queue, this);
@@ -671,8 +667,7 @@ Client.config = {
       }
 
       // cleanup
-      dataSet = '';
-      tokenSet = metaData = undefined;
+      dataSet = tokenSet = metaData = undefined;
 
       // check if we need to remove an empty item from the array, as splitting on /r/n might cause an empty
       // item at the end..
@@ -771,6 +766,8 @@ Client.config = {
       flag = FLAG_JSON;
       value = JSON.stringify(value);
     }
+    
+    value = Utils.escapeValue(value);
 
     length = Buffer.byteLength(value);
     if (length > this.maxValue) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -129,3 +129,13 @@ exports.Iterator = function iterator (collection, callback) {
     return index < maximum;
   };
 };
+
+//Escapes values by putting backslashes before line breaks
+exports.escapeValue = function(value) {
+  return value.replace(/(\r|\n)/g, '\\$1');
+};
+
+//Unescapes escaped values by removing backslashes before line breaks
+exports.unescapeValue = function(value) {
+  return value.replace(/\\(\r|\n)/g, '$1');
+};

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -445,4 +445,97 @@ describe("Memcached GET SET", function() {
           });
         });
     });
+
+    /**
+     * Make sure that a string beginning with OK is not interpreted as
+     * a command response.
+     */
+    it("set and get a string beginning with OK", function(done) {
+        var memcached = new Memcached(common.servers.single)
+          , message = 'OK123456'
+          , testnr = ++global.testnumbers
+          , callbacks = 0;
+
+        memcached.set("test:" + testnr, message, 1000, function(error, ok){
+          ++callbacks;
+
+          assert.ok(!error);
+          ok.should.be.true;
+
+          memcached.get("test:" + testnr, function(error, answer){
+            ++callbacks;
+
+            assert.ok(!error);
+
+            assert.ok(typeof answer === 'string');
+            answer.should.eql(message);
+
+            memcached.end(); // close connections
+            assert.equal(callbacks, 2);
+            done();
+          });
+        });
+    });
+
+  /**
+   * Make sure that a string beginning with OK is not interpreted as
+   * a command response.
+   */
+  it("set and get a string beginning with VALUE", function(done) {
+    var memcached = new Memcached(common.servers.single)
+      , message = 'VALUE hello, I\'m not really a value.'
+      , testnr = ++global.testnumbers
+      , callbacks = 0;
+
+    memcached.set("test:" + testnr, message, 1000, function(error, ok){
+      ++callbacks;
+
+      assert.ok(!error);
+      ok.should.be.true;
+
+      memcached.get("test:" + testnr, function(error, answer){
+        ++callbacks;
+
+        assert.ok(!error);
+
+        assert.ok(typeof answer === 'string');
+        answer.should.eql(message);
+
+        memcached.end(); // close connections
+        assert.equal(callbacks, 2);
+        done();
+      });
+    });
+  });
+
+  /**
+   * Make sure that a string containing line breaks are escaped and
+   * unescaped correctly.
+   */
+  it("set and get a string with line breaks", function(done) {
+    var memcached = new Memcached(common.servers.single)
+      , message = '1\n2\r\n3\n\r4\\n5\\r\\n6\\n\\r7'
+      , testnr = ++global.testnumbers
+      , callbacks = 0;
+
+    memcached.set("test:" + testnr, message, 1000, function(error, ok){
+      ++callbacks;
+
+      assert.ok(!error);
+      ok.should.be.true;
+
+      memcached.get("test:" + testnr, function(error, answer){
+        ++callbacks;
+
+        assert.ok(!error);
+
+        assert.ok(typeof answer === 'string');
+        answer.should.eql(message);
+
+        memcached.end(); // close connections
+        assert.equal(callbacks, 2);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Hi Arnout

Thanks for your awesome node module!

This single commit should fix the issue with values starting with keywords such as OK, VALUE as mentioned here: https://github.com/3rd-Eden/node-memcached/issues/59.

The change includes escaping line breaks in values before set commands, and unescaping after get command.

I also added the following unit tests
- Added unit tests for OK and for VALUE
- Added unit test for checking correctly escaped line breaks

All unit tests pass after the change.

Please let me hear from you, if you have any questions.

Sebastian
