### PR TITLE
Changed all errors to be instances of Error instead of plain strings (second try)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ function ping (host, callback) {
   });
 
   pong.stderr.on('data', function stderrdata (data) {
-    callback(data.toString().split('\n')[0].substr(14), false);
+    callback(new Error(data.toString().split('\n')[0].substr(14)), false);
     pong.kill();
   });
 }

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -244,7 +244,7 @@ Client.config = {
 
     // check if the server is still alive
     if (server in this.issues && this.issues[server].failed) {
-      return query.callback && query.callback('Server not available');
+      return query.callback && query.callback(new Error('Server not available'));
     }
 
     this.connect(server, function allocateMemcachedConnection(error, S) {
@@ -256,10 +256,10 @@ Client.config = {
 
       // check for issues
       if (error) return query.callback && query.callback(error);
-      if (!S) return query.callback && query.callback('Connect did not give a server');
+      if (!S) return query.callback && query.callback(new Error('Connect did not give a server'));
 
       if (S.readyState !== 'open') {
-        return query.callback && query.callback('Connection readyState is set to ' + S.readySate);
+        return query.callback && query.callback(new Error('Connection readyState is set to ' + S.readySate));
       }
 
       // used for request timing
@@ -362,17 +362,19 @@ Client.config = {
     }
 
   , 'NOT_STORED': function notstored(tokens, dataSet, err) {
-      err.push('Item is not stored');
+      var errObj = new Error('Item is not stored');
+      errObj.notStored = true;
+      err.push(errObj);
       return [CONTINUE, false];
     }
 
   , 'ERROR': function error(tokens, dataSet, err) {
-      err.push('Received an ERROR response');
+      err.push(new Error('Received an ERROR response'));
       return [FLUSH, false];
     }
 
   , 'CLIENT_ERROR': function clienterror(tokens, dataSet, err) {
-      err.push(tokens.splice(1).join(' '));
+      err.push(new Error(tokens.splice(1).join(' ')));
       return [CONTINUE, false];
     }
 
@@ -661,7 +663,7 @@ Client.config = {
         metaData = S.metaData.shift();
         if (metaData && metaData.callback){
           metaData.execution = Date.now() - metaData.start;
-          metaData.callback.call(metaData, 'Unknown response from the memcached server: "' + token + '"', false);
+          metaData.callback.call(metaData, new Error('Unknown response from the memcached server: "' + token + '"'), false);
         }
       }
 
@@ -770,7 +772,7 @@ Client.config = {
 
     length = Buffer.byteLength(value);
     if (length > this.maxValue) {
-      return privates.errorResponse('The length of the value is greater than ' + this.maxValue, callback);
+      return privates.errorResponse(new Error('The length of the value is greater than ' + this.maxValue), callback);
     }
 
     this.command(function settersCommand(noreply) {


### PR DESCRIPTION
Hi

I updated to latest master in this pull request. I have closed #73.

This makes debugging a lot easier, and adds to the module's robustness.

The error for "Item is not stored" has a special use case, as it's something you expect could happen. The error object for this error message has a notStore=true property. It's useful like this:

``` javascript
memcached.add('only-set-me-once', Date.now(), 0, function(err) {
    if (err && !err.notStored)) {
        //Only throw the error, if it wasn't the notStored "error", which we expect to happen sometimes.
        throw err;
    }
    //Callback or whatever you wanna do
});
```

Unit tests pass after the changes.

Sebastian
