### PR TITLE
Fix for hashing long keys and spaces in key names

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,8 +4,7 @@ var createHash = require('crypto').createHash
   , toString = Object.prototype.toString;
 
 exports.validateArg = function validateArg (args, config) {
-  var err
-    , callback;
+  var err;
 
   args.validate.forEach(function (tokens) {
     var key = tokens[0]
@@ -58,7 +57,7 @@ exports.validateArg = function validateArg (args, config) {
               args[key] = createHash('md5').update(value).digest('hex');
 
               // also make sure you update the command
-              args.command.replace(value, args[key]);
+              args.command = args.command.replace(value, args[key]);
             } else {
               err = 'Argument "' + key + '" is longer than the maximum allowed length of ' + config.maxKeySize;
             }
@@ -76,7 +75,7 @@ exports.validateArg = function validateArg (args, config) {
   });
 
   if (err){
-    if(callback) callback(err, false);
+    if(args.callback) args.callback(new Error(err));
     return false;
   }
 

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -538,4 +538,53 @@ describe("Memcached GET SET", function() {
       });
     });
   });
+  
+  /**
+    * Make sure long keys are hashed
+    */
+   it("make sure you can get really long strings", function(done) {
+     var memcached = new Memcached(common.servers.single)
+       , message = 'VALUE hello, I\'m not really a value.'
+       , testnr = "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"+(++global.testnumbers)
+       , callbacks = 0;
+
+     memcached.set("test:" + testnr, message, 1000, function(error, ok){
+       ++callbacks;
+
+       assert.ok(!error);
+       ok.should.be.true;
+
+       memcached.get("test:" + testnr, function(error, answer){
+         ++callbacks;
+
+         assert.ok(!error);
+
+         assert.ok(typeof answer === 'string');
+         answer.should.eql(message);
+
+         memcached.end(); // close connections
+         assert.equal(callbacks, 2);
+         done();
+       });
+     });
+   });
+   
+   /**
+     * Make sure keys with spaces return an error
+     */
+    it("errors on spaces in strings", function(done) {
+      var memcached = new Memcached(common.servers.single)
+        , message = 'VALUE hello, I\'m not really a value.'
+        , testnr = " "+(++global.testnumbers)
+        , callbacks = 0;
+
+      memcached.set("test:" + testnr, message, 1000, function(error, ok){
+        ++callbacks;
+
+        assert.ok(error);
+        assert.ok(error.message == 'The key should not contain any whitespace or new lines')
+        
+        done();
+      });
+    });
 });


### PR DESCRIPTION
I've fixed two issues with the validateArgs function having to do with invalid keys.
