### PR TITLE
Ability to setup different values for connection and idle timeouts

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -78,6 +78,7 @@ Client.config = {
   , poolSize: 10            // maximal parallel connections
   , reconnect: 18000000     // if dead, attempt reconnect each xx ms
   , timeout: 5000           // after x ms the server should send a timeout if we can't connect
+  , idle: 5000              // connection idle timeout
   , retries: 5              // amount of retries before server is dead
   , retry: 30000            // timeout between retries, all call will be marked as cache miss
   , remove: false           // remove server if dead if false, we will attempt to reconnect
@@ -138,7 +139,10 @@ Client.config = {
       var S = Array.isArray(serverTokens)
           ? new Stream
           : new Socket
-        , Manager = this;
+        , Manager = this
+        , streamTimeout = function () {
+            Manager.remove(this);
+          };
 
       // config the Stream
       S.streamID = sid++;
@@ -158,9 +162,13 @@ Client.config = {
             Manager.remove(this);
           }
         , data: curry(memcached, privates.buffer, S)
-        , timeout: function streamTimeout() {
-            Manager.remove(this);
+        , connect: function streamConnect() {
+            if (this.memcached.idle > this.memcached.timeout) {
+              this.setTimeout(0, streamTimeout);
+              this.setTimeout(this.memcached.idle, streamTimeout);
+            }
           }
+        , timeout: streamTimeout
         , end: S.end
       });
 


### PR DESCRIPTION
Commit adds an option `idle` to set timeout for connection idle different from connection timeout.
