### PR TITLE
allow callback to determine if a get() returns no value

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -427,7 +427,7 @@ Client.config = {
     }
 
   , 'END': function end(tokens, dataSet, err, queue) {
-      if (!queue.length) queue.push(false);
+      if (!queue.length) queue.push(undefined);
       return [FLUSH, true];
     }
 


### PR DESCRIPTION
When result was false (the old behavior), callback could not tell if the value was false or if the key was not found. This allows the callback to differentiate between the two
