### PR TITLE
Corrected argument order for privates.setters

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -830,7 +830,7 @@ Client.config = {
   // commands will use the same syntax for the Memcached server. Some commands
   // do not require a lifetime and a flag, but the memcached server is smart
   // enough to ignore those.
-  privates.setters = function setters(type, validate, key, value, lifetime, callback, cas) {
+  privates.setters = function setters(type, validate, key, lifetime, value, callback, cas) {
     var fullkey = this.namespace + key;
     var flag = 0
       , valuetype = typeof value


### PR DESCRIPTION
The privates.setters function's arguments were out of order.
