### PR TITLE
expose jackpot retry options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ formatted in an JavaScript `object`. They both use the same object structure:
   reconnect every x milliseconds.
 * `timeout`: *5000*, after x ms the server should send a timeout if we can't
   connect. This will also be used close the connection if we are idle.
-* `retries`: *5*, amount of tries before we mark the server as dead.
-* `retry`: *30000*, timeout between each retry in x milliseconds.
+* `retries`: *5*, How many times to retry socket allocation for given request
+* `failures`: *5*, Number of times a server may have issues before marked dead.
+* `retry`: *30000*, time to wait between failures before putting server back in
+  service.
 * `remove`: *false*, when the server is marked as dead you can remove it from
   the pool so all other will receive the keys instead.
 * `failOverServers`: *undefined*, the ability use these servers as failover when
@@ -535,9 +537,9 @@ following 3 will always be present in all error events:
 The following properties depend on the type of event that is send. If we are
 still in our retry phase the details will also contain:
 
-* `retries`: the amount of retries left before we mark the server as dead.
-* `totalRetries`: the total amount of retries we did on this server, as when the
-  server has been reconnected after it's dead the `retries` will be rest to
+* `failures`: the amount of failures left before we mark the server as dead.
+* `totalFailures`: the total amount of failures that occurred on this server, as when the
+  server has been reconnected after it's dead the `failures` will be rest to
   defaults and messages will be removed.
 
 If the server is dead these details will be added:

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -27,7 +27,7 @@ function IssueLog (args) {
   this.failed = false;
   this.locked = false;
 
-  this.totalRetries = 0;
+  this.totalFailures = 0;
   this.retry = 0;
   this.totalReconnectsAttempted = 0;
   this.totalReconnectsSuccess = 0;
@@ -43,7 +43,7 @@ issues.log = function log (message) {
 
   this.failed = true;
   this.messages.push(message || 'No message specified');
-  if (this.retries && !this.locked) {
+  if (this.failures && !this.locked) {
     this.locked = true;
     setTimeout(issue.attemptRetry.bind(issue), this.retry);
     return this.emit('issue', this.details);
@@ -62,14 +62,14 @@ Object.defineProperty(issues, 'details', {
     res.tokens = this.tokens;
     res.messages = this.messages;
 
-    if (this.retries) {
-      res.retries = this.retries;
-      res.totalRetries = this.totalRetries;
+    if (this.failures) {
+      res.failures = this.failures;
+      res.totalFailures = this.totalFailures;
     } else {
       res.totalReconnectsAttempted = this.totalReconnectsAttempted;
       res.totalReconnectsSuccess = this.totalReconnectsSuccess;
       res.totalReconnectsFailed = this.totalReconnectsAttempted - this.totalReconnectsSuccess;
-      res.totalDownTime = (res.totalReconnectsFailed * this.reconnect) + (this.totalRetries * this.retry);
+      res.totalDownTime = (res.totalReconnectsFailed * this.reconnect) + (this.totalFailures * this.retry);
     }
 
     return res;
@@ -77,8 +77,8 @@ Object.defineProperty(issues, 'details', {
 });
 
 issues.attemptRetry = function attemptRetry () {
-  this.totalRetries++;
-  this.retries--;
+  this.totalFailures++;
+  this.failures--;
   this.failed = false;
   this.locked = false;
 };

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -74,10 +74,16 @@ Client.config = {
   , algorithm: 'crc32'      // hashing algorithm that is used for key mapping
 
   , poolSize: 10            // maximal parallel connections
+  , retries: 5              // Connection pool retries to pull connection from pool
+  , factor: 3               // Connection pool retry exponential backoff factor
+  , minTimeout: 1000        // Connection pool retry min delay before retrying
+  , maxTimeout: 60000       // Connection pool retry max delay before retrying
+  , randomize: false        // Connection pool retry timeout randomization
+
   , reconnect: 18000000     // if dead, attempt reconnect each xx ms
   , timeout: 5000           // after x ms the server should send a timeout if we can't connect
-  , retries: 5              // amount of retries before server is dead
-  , retry: 30000            // timeout between retries, all call will be marked as cache miss
+  , failures: 5             // Number of times a server can have an issue before marked dead
+  , retry: 30000            // When a server has an error, wait this amount of time before retrying
   , remove: false           // remove server if dead if false, we will attempt to reconnect
   , redundancy: false       // allows you do re-distribute the keys over a x amount of servers
   , keyCompression: true    // compress keys if they are to large (md5)
@@ -133,6 +139,10 @@ Client.config = {
 
     manager = new Jackpot(this.poolSize);
     manager.retries = memcached.retries;
+    manager.factor = memcached.factor;
+    manager.minTimeout = memcached.minTimeout;
+    manager.maxTimeout = memcached.maxTimeout;
+    manager.randomize = memcached.randomize;
 
     manager.factory(function factory() {
       var S = Array.isArray(serverTokens)
@@ -332,7 +342,7 @@ Client.config = {
           server: server
         , tokens: S.tokens
         , reconnect: this.reconnect
-        , retries: this.retries
+        , failures: this.failures
         , retry: this.retry
         , remove: this.remove
       });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   , "dependencies": {
         "hashring": "0.0.x"
-      , "jackpot": ">=0.0.2"
+      , "jackpot": ">=0.0.4"
     }
   , "devDependencies": {
         "mocha": "*"

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -36,7 +36,8 @@ describe('Memcached connections', function () {
   it('should remove a failed server', function(done) {
     var memcached = new Memcached('127.0.1:1234', {
       timeout: 1000,
-      retries: 3,
+      retries: 0,
+      failures: 0,
       retry: 100,
       remove: true });
 
@@ -56,7 +57,8 @@ describe('Memcached connections', function () {
   it('should rebalance to remaining healthy server', function(done) {
     var memcached = new Memcached(['127.0.1:1234', common.servers.single], {
       timeout: 1000,
-      retries: 3,
+      retries: 0,
+      failures: 0,
       retry: 100,
       remove: true,
       redundancy: true });


### PR DESCRIPTION
also splits connection allocation `retries` option from server retries option.  server retries option is called `failures` as in the number of failures to allow on the server before marking it as dead.  For 3rd-Eden/node-memcached#126
