### PR TITLE
don't report connect issues on idle socket

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -159,7 +159,7 @@ Client.config = {
           }
         , data: curry(memcached, privates.buffer, S)
         , timeout: function streamTimeout() {
-            memcached.connectionIssue('Stream timout', S);
+            Manager.remove(this);
           }
         , error: function streamError() {
             // callback called when retries is exhausted


### PR DESCRIPTION
Fully read through Jackpot and I see this timeout here should not report a connectionIssue.  I still need to sort through https://github.com/3rd-Eden/node-memcached/pull/93 to see what makes sense there still.  With https://github.com/3rd-Eden/node-memcached/pull/127 you can control the connection timeout.
