### PR TITLE
Fixed wrong examples for Set and Replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Stores a new value in Memcached.
 `callback`: **Function** the callback
 
 ```js
-memcached.set('foo', 10, 'bar', function (err) {
+memcached.set('foo', 'bar', 10, function (err) {
   // stuff
 });
 ```
@@ -222,7 +222,7 @@ Replaces the value in memcached.
 `callback`: **Function** the callback
 
 ```js
-memcached.replaces('foo', 10, 'bar', function (err) {
+memcached.replace('foo', 'bar', 10, function (err) {
   // stuff
 });
 ```


### PR DESCRIPTION
Fixed wrong order of params in set and replace function examples.
Fixed typo in replace function example.
