### PR TITLE
Require Jackpot 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   , "dependencies": {
         "hashring": "0.0.x"
-      , "jackpot": ">=0.0.4"
+      , "jackpot": ">=0.0.6"
     }
   , "devDependencies": {
         "mocha": "*"


### PR DESCRIPTION
> =0.0.4 screwed up my environment because it wouldn't update Jackpot coming from 0.0.5. Perhaps we can switch permanently to 0.0.6?
