### PR TITLE
error on timeout now handled by jackpot

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -155,8 +155,8 @@ Client.config = {
         , idleTimeout = function() {
             Manager.remove(this);
           }
-        , streamError = function() {
-            memcached.connectionIssue('Stream error', S);
+        , streamError = function(e) {
+            memcached.connectionIssue(e.toString(), S);
             Manager.remove(this);
         };
 
@@ -178,10 +178,14 @@ Client.config = {
             Manager.remove(this);
           }
         , data: curry(memcached, privates.buffer, S)
-        , error: streamError
         , connect: function streamConnect() {
-            // Close idle connections
+            // Jackpot handles any pre-connect timeouts by calling back
+            // with the error object.
             this.setTimeout(this.memcached.idle, idleTimeout);
+            // Jackpot handles any pre-connect errors, but does not handle errors
+            // once a connection has been made, nor does Jackpot handle releasing
+            // connections if an error occurs post-connect
+            this.on('error', streamError);
           }
         , end: S.end
       });
@@ -299,11 +303,21 @@ Client.config = {
       }
 
       // check for issues
-      if (error) return query.callback && memcached.makeCallback(query.callback,error);
-      if (!S) return query.callback && memcached.makeCallback(query.callback,new Error('Connect did not give a server'));
+      if (error) {
+        memcached.connectionIssue(error.toString(), S);
+        return query.callback && memcached.makeCallback(query.callback,error);
+      }
+
+      if (!S) {
+        var message = 'Connect did not give a server';
+        memcached.connectionIssue(message);
+        return query.callback && memcached.makeCallback(query.callback,new Error(message));
+      }
 
       if (S.readyState !== 'open') {
-        return query.callback && memcached.makeCallback(query.callback,new Error('Connection readyState is set to ' + S.readySate));
+        var message = 'Connection readyState is set to ' + S.readyState;
+        memcached.connectionIssue(message, S);
+        return query.callback && memcached.makeCallback(query.callback,new Error(message));
       }
 
       // used for request timing

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -154,6 +154,7 @@ describe('Memcached connections', function () {
     // First request will mark server failed
     memcached.get('idontcare', function(err) {
       assert.throws(function() { throw err }, /connect ECONNREFUSED/);
+      // Wait 10ms, server should be back online
       setTimeout(function() {
         // Second request will mark server dead
         memcached.get('idontcare', function(err) {
@@ -171,10 +172,10 @@ describe('Memcached connections', function () {
                   memcached.end();
                   done();
                 });
-              }, 110);
+              }, 150);
             });
           });
-      },10); // Make sure `retry`, which is immediate, has passed
+      },10);
     });
   });
   it('should return error on connection timeout', function(done) {
@@ -207,5 +208,26 @@ describe('Memcached connections', function () {
         done();
       }, 100);
     });
+  });
+  it('should remove server if error occurs after connection established', function(done) {
+    var memcached = new Memcached(common.servers.single, {
+      poolSize: 1,
+      retries: 0,
+      timeout: 1000,
+      idle: 5000,
+      failures: 0 });
+
+    // Should work fine
+    memcached.get('idontcare', function(err) {
+      assert.ifError(err);
+      // Fake an error on the connected socket which should mark server failed
+      var S = memcached.connections[common.servers.single].pool.pop();
+      S.emit('error', new Error('Dummy error'));
+      memcached.get('idontcare', function(err) {
+        assert.throws(function() { throw err; }, /Server not available/);
+        done();
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Fixes broken tests in 3rd-Eden/node-memcached#135 ... now that Jackpot returns error on timeout when trying to connect socket, node-memcached no longer needs to do so.
