### PR TITLE
add failures time limit

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -44,11 +44,19 @@ issues.log = function log (message) {
 
   this.failed = true;
   this.messages.push(message || 'No message specified');
+
+  // All failures must occur within `failuresTimeout` ms from the initial
+  // failure in order for node to be disconnected or removed.
+  if (this.failures && this.failures == this.config.failures)
+    this.failuresResetId = setTimeout(issue.failuresReset.bind(issue), this.failuresTimeout);
+
   if (this.failures && !this.locked) {
     this.locked = true;
     setTimeout(issue.attemptRetry.bind(issue), this.retry);
     return this.emit('issue', this.details);
   }
+
+  if (this.failuresResetId) clearTimeout(this.failuresResetId);
 
   if (this.remove) return this.emit('remove', this.details);
 
@@ -56,6 +64,11 @@ issues.log = function log (message) {
       this.isScheduledToReconnect = true;
       setTimeout(issue.attemptReconnect.bind(issue), this.reconnect);
   }
+};
+
+issues.failuresReset = function failuresReset() {
+  //this.failures = this.config.failures;
+  Utils.merge(this, JSON.parse(JSON.stringify(this.config)));
 };
 
 Object.defineProperty(issues, 'details', {

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -83,6 +83,7 @@ Client.config = {
   , reconnect: 18000000     // if dead, attempt reconnect each xx ms
   , timeout: 5000           // after x ms the server should send a timeout if we can't connect
   , failures: 5             // Number of times a server can have an issue before marked dead
+  , failuresTimeout: 300000   // Time after which `failures` will be reset to original value, since last failure
   , retry: 30000            // When a server has an error, wait this amount of time before retrying
   , idle: 5000              // Remove connection from pool when no I/O after `idle` ms
   , remove: false           // remove server if dead if false, we will attempt to reconnect
@@ -365,6 +366,7 @@ Client.config = {
         , tokens: S.tokens
         , reconnect: this.reconnect
         , failures: this.failures
+        , failuresTimeout: this.failuresTimeout
         , retry: this.retry
         , remove: this.remove
       });


### PR DESCRIPTION
Adds a time limit setting within which all `failures` must occur, otherwise `failures` will be reset to its original value.  Avoids a situation where, if `failures` is set to three, and one failure occurs today, one tomorrow, and another in five days, that these three failures don't cause the node to be marked dead or removed.  Instead, the idea is that the three failures should occur in a similar time frame, such as all within ten minutes of each other.
