### PR TITLE
Issue #92 Include failOverServers on the IssueLog object

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -369,6 +369,7 @@ Client.config = {
         , failuresTimeout: this.failuresTimeout
         , retry: this.retry
         , remove: this.remove
+        , failOverServers: this.failOverServers || null
       });
 
       // proxy the events


### PR DESCRIPTION
IssueLog object hasn't any reference to the failOverServers property, or that was lost at some point. I just added back
