### PR TITLE
Fixed a problem with getMulti, multi server, and namespace.

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -842,7 +842,7 @@ Client.config = {
 
       // add all responses to the array
       (Array.isArray(results) ? results : [results]).forEach(function each(value) {
-        if (memcached.namespace.length) {
+        if (value && memcached.namespace.length) {
           var ns_key = Object.keys(value)[0]
             , newvalue = {};
 


### PR DESCRIPTION
Fixed errors that occured in the following conditions;
- when multi get is used.
- when multi servers are in use.
- when custom namespace is set.
- when there is a server without any caches for the keys that are requested.
