### PR TITLE
Use util.inherits instead of IssueLog.prototype = new EventEmitter

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -2,7 +2,8 @@
 
 var EventEmitter = require('events').EventEmitter
   , spawn = require('child_process').spawn
-  , Utils = require('./utils');
+  , Utils = require('./utils')
+  , util = require('util');
 
 exports.IssueLog = IssueLog;         // connection issue handling
 exports.Available = ping;            // connection availablity
@@ -37,7 +38,8 @@ function IssueLog (args) {
   EventEmitter.call(this);
 }
 
-var issues = IssueLog.prototype = new EventEmitter;
+util.inherits(IssueLog, EventEmitter);
+var issues = IssueLog.prototype;
 
 issues.log = function log (message) {
   var issue = this;


### PR DESCRIPTION
For [v0.10 compatibility](https://github.com/joyent/node/wiki/API-changes-between-v0.8-and-v0.10). 
