### PR TITLE
Inconsistent consistent hashing algorithm, not matching libmemcached

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Memcached server uses the same properties:
 * `maxExpiration`: *2592000*, the maximum expiration time of keys (in seconds).
 * `maxValue`: *1048576*, the maximum size of a value.
 * `poolSize`: *10*, the maximum size of the connection pool.
-* `algorithm`: *crc32*, the hashing algorithm used to generate the `hashRing` values.
+* `algorithm`: *md5*, the hashing algorithm used to generate the `hashRing` values.
 * `reconnect`: *18000000*, the time between reconnection attempts (in milliseconds).
 * `timeout`: *5000*, the time after which Memcached sends a connection timeout (in milliseconds).
 * `retries`: *5*, the number of socket allocation retries per request.
@@ -443,6 +443,13 @@ var memcached = new Memcached([ '192.168.0.102:11211', '192.168.0.103:11211' ]);
 memcached.on('failure', function( details ){ sys.error( "Server " + details.server + "went down due to: " + details.messages.join( '' ) ) });
 memcached.on('reconnecting', function( details ){ sys.debug( "Total downtime caused by server " + details.server + " :" + details.totalDownTime + "ms")});
 ```
+
+# Compatibility
+For compatibility with other [libmemcached](http://libmemcached.org/Clients.html) clients they need to have the behavior
+`ketama_weighted` set to true and the `hash` set to the same as `node-memcached`'s
+`algorithm`.
+
+Due to client dependent type flags it is unlikely that any types other than `string` will work.
 
 # Contributors
 

--- a/doc/index.html
+++ b/doc/index.html
@@ -247,7 +247,7 @@ this.connections[server].allocate(callback);</code></pre>
 // or just gives all servers if we don't have keys
 if (keys){
   keys.forEach(function fetchMultipleServers(key){
-    var server = memcached.HashRing.getNode(key);
+    var server = memcached.HashRing.get(key);
     if (map[server]){
       map[server].push(key);
     } else {
@@ -281,7 +281,7 @@ var query = queryCompiler()
 if (query.validation &amp;&amp; !Utils.validateArg(query, this)) return;
 
 // fetch servers
-server = server ? server : redundancy &amp;&amp; queryRedundancy ? (redundancy = this.HashRing.createRange(query.key, (this.redundancy + 1), true)).shift() : this.HashRing.getNode(query.key);
+server = server ? server : redundancy &amp;&amp; queryRedundancy ? (redundancy = this.HashRing.createRange(query.key, (this.redundancy + 1), true)).shift() : this.HashRing.get(query.key);
 
 // check if the server is still alive
 if (server in this.issues &amp;&amp; this.issues[server].failed) return query.callback &amp;&amp; query.callback(false, false);

--- a/examples/consistent_hashing.js
+++ b/examples/consistent_hashing.js
@@ -12,9 +12,9 @@ var Ring = new HashRing(
 	);
 
 // Return the server based on the key
-process.stdout.write( Ring.getNode( "my-super-secret-cache-key" ) );
-process.stdout.write( Ring.getNode( "hello-world" ) );
-process.stdout.write( Ring.getNode( "my-super-secret-cache-key" ) );
+process.stdout.write( Ring.get( "my-super-secret-cache-key" ) );
+process.stdout.write( Ring.get( "hello-world" ) );
+process.stdout.write( Ring.get( "my-super-secret-cache-key" ) );
 
 // Different algorithms produce different hash maps. So choose wisely
 var sha1Ring  = new HashRing(
@@ -30,6 +30,6 @@ var sha1Ring  = new HashRing(
 		'sha1' // optional algorithm for key hashing
 	);
 
-process.stdout.write( sha1Ring.getNode( "my-super-secret-cache-key" ) );
-process.stdout.write( sha1Ring.getNode( "hello-world" ) );
-process.stdout.write( sha1Ring.getNode( "my-super-secret-cache-key" ) );
+process.stdout.write( sha1Ring.get( "my-super-secret-cache-key" ) );
+process.stdout.write( sha1Ring.get( "hello-world" ) );
+process.stdout.write( sha1Ring.get( "my-super-secret-cache-key" ) );

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -71,7 +71,7 @@ Client.config = {
   , maxValue: 1048576       // max length of value allowed by Memcached
   , activeQueries: 0
   , maxQueueSize: -1
-  , algorithm: 'crc32'      // hashing algorithm that is used for key mapping
+  , algorithm: 'md5'      // hashing algorithm that is used for key mapping
 
   , poolSize: 10            // maximal parallel connections
   , retries: 5              // Connection pool retries to pull connection from pool
@@ -226,7 +226,7 @@ Client.config = {
       keys.forEach(function fetchMultipleServers(key) {
         var server = memcached.servers.length === 1
           ? memcached.servers[0]
-          : memcached.HashRing.getNode(key);
+          : memcached.HashRing.get(key);
 
         if (map[server]){
           map[server].push(key);
@@ -285,7 +285,7 @@ Client.config = {
           redundancy = this.HashRing.createRange(query.key, (this.redundancy + 1), true);
           server = redundancy.shift();
         } else {
-          server = this.HashRing.getNode(query.key);
+          server = this.HashRing.get(query.key);
         }
       }
     }
@@ -401,7 +401,7 @@ Client.config = {
             if (this.failOverServers && this.failOverServers.length) {
               memcached.HashRing.replaceServer(server, this.failOverServers.shift());
             } else {
-              memcached.HashRing.removeServer(server);
+              memcached.HashRing.remove(server);
               memcached.emit('failure', details);
             }
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "url": "http://github.com/3rd-Eden/node-memcached.git"
   },
   "dependencies": {
-    "hashring": "0.0.x",
+    "hashring": "1.0.x",
     "jackpot": ">=0.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
The version of hashring used by node-memcached does not correctly implement consistent hashing like libketama, which prevents using it to cache data between several different libmemcached clients. Updating to hashring 1.0.8 appears to have fixed this.

I have also updated the readme for new behaviour in hashring 1.0.8. I've also added a note about compatibility with other libmemcached clients using consistent hashing. Had to change the default algorithm to md5 as the crc32 implementation causes errors now.

I've updated all the deprecation warnings from the update and the tests show everything working fine.
