### PR TITLE
Callbacks hang when memcache fails

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -162,7 +162,7 @@ Client.config = {
             var metaData = S.metaData.shift();
             if (metaData && metaData.callback){
                 metaData.execution = Date.now() - metaData.start;
-                memcached.delegateCallback(metaData, new Error('Stream error'), false, metaData.callback);
+                memcached.delegateCallback(metaData, e, false, metaData.callback);
             }
         };
 


### PR DESCRIPTION
Fixes #195, and possibly #185

Currently if any memcache server goes down once a connection is made, Memcached requests will hang and not call their callbacks. This comment from the code explains how this is relevant to Jackpot:

```
// Jackpot handles any pre-connect errors, but does not handle errors
// once a connection has been made, nor does Jackpot handle releasing
// connections if an error occurs post-connect
```

I've been working with @denisspb on a fix for this. This PR fixes the issue with the hanging callbacks, but since everyone may want to handle this fail differently, it is still up to the consumer to release the connections via `close()`, `end()`, etc.

Let me know how I can help get this through. This can be a huge problem in production and should be fixed as soon as possible.
