### PR TITLE
[test] Fix `shell` not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "pre-commit": "*"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha $(shell find test -name '*.test.js')"
+    "test": "./node_modules/.bin/mocha ./test/*.test.js"
   }
 }


### PR DESCRIPTION
When I run `git commit` in my iTerm, I get the following error message from the precommit hook:

```
> memcached@0.2.8 test /Users/Fiona/workspace/node-memcached
> mocha $(shell find test -name '*.test.js')

sh: shell: command not found
```

This PRs uses a regexp to find the test files instead of calling out to `shell find`.
