### PR TITLE
Improve libmemcached compatibility.

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -59,8 +59,10 @@ function Client (args, options) {
   Utils.merge(this, options);
 
   this.servers = servers;
+  var compatibility = this.compatibility || this.compatiblity;
   this.HashRing = new HashRing(args, this.algorithm, {
-    compatibility: this.compatibility || this.compatiblity
+    compatibility: compatibility,
+    default_port: (compatibility == 'ketama') ? 11211 : null
   });
   this.connections = {};
   this.issues = [];


### PR DESCRIPTION
When using ketama compatibility, utilise the `default_port` option from 3rd-Eden/node-hashring#23
