### PR TITLE
fix parsing of version response

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -546,7 +546,7 @@ Client.config = {
     }
 
   , 'VERSION': function version(tokens, dataSet) {
-      var versionTokens = /(\d+)(?:\.)(\d+)(?:\.)(\d+)$/.exec(tokens.pop());
+      var versionTokens = /(\d+)(?:\.)(\d+)(?:\.)(\d+)$/.exec(tokens[1]);
 
       return [CONTINUE, {
         server: this.serverAddress

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -244,7 +244,7 @@ describe('Memcached connections', function () {
         assert.deepEqual(memcached.connections[common.servers.single].pool.length, 0);
         memcached.end();
         done();
-      }, 100);
+      }, 105);
     });
   });
   it('should remove server if error occurs after connection established', function(done) {

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -200,7 +200,33 @@ describe('Memcached connections', function () {
       failures: 0 });
 
     memcached.get('idontcare', function(err) {
-      assert.throws(function() { throw err }, /Timed out while trying to establish connection/);
+      assert.throws(function() { throw err }, /Timed out while trying to establish connection|EHOSTUNREACH/);
+      memcached.end();
+      done();
+    });
+  });
+  it('should return memcached version (single)', function(done){
+    var memcached = new Memcached(common.servers.single, {
+      retries: 0,
+      timeout: 100,
+      idle: 100,
+      failures: 0 });
+    memcached.version(function(err, v) {
+      assert(v[0].version);
+      memcached.end();
+      done();
+    });
+  });
+  it('should return memcached version (multi)', function(done){
+    var memcached = new Memcached(common.servers.multi, {
+      retries: 0,
+      timeout: 100,
+      idle: 100,
+      failures: 0 });
+    memcached.version(function(err, v) {
+      assert(v[0].version);
+      assert(v[1].version);
+      assert(v[2].version);
       memcached.end();
       done();
     });


### PR DESCRIPTION
memcached returns "VERSION x.x.x" for the version command.  This was previously attempting to parse the "VERSION" string instead of the "x.x.x" string, resulting in an error.  This output from memcached has been consistent from (at least) v1.2.

I see that I've also inadvertently committed a fix in the 'should return error on connection timeout' where I was getting an EHOSTUNREACH exception instead of a timeout.  It's probably worth leaving this in, because others will undoubtedly encounter this test "failure" otherwise.