### PR TITLE
allow valid set() calls without a callback to proceed.  These were fa…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,7 +50,7 @@ exports.validateArg = function validateArg (args, config) {
         break;
 
       case Function:
-        if (toString.call(value) !== '[object Function]') {
+        if (typeof obj !== "undefined" && toString.call(value) !== '[object Function]') {
           err = 'Argument "' + key + '" is not a valid Function.';
         }
 


### PR DESCRIPTION
…iling silently for no reason other than the fact that a callback was not provided.

This fixes issue #248