### PR TITLE
Defend VERSION token parse against memcached 1.4.14 (ubuntu)

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -546,7 +546,7 @@ Client.config = {
     }
 
   , 'VERSION': function version(tokens, dataSet) {
-      var versionTokens = /(\d+)(?:\.)(\d+)(?:\.)(\d+)$/.exec(tokens.pop());
+      var versionTokens = /(\d+)(?:\.)(\d+)(?:\.)(\d+)$/.exec(tokens[1]);
 
       return [CONTINUE, {
         server: this.serverAddress

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -218,7 +218,7 @@ describe('Memcached connections', function () {
         assert.deepEqual(memcached.connections[common.servers.single].pool.length, 0);
         memcached.end();
         done();
-      }, 100);
+      }, 110);
     });
   });
   it('should remove server if error occurs after connection established', function(done) {


### PR DESCRIPTION
We noticed that Ubuntu likes to put their name in everything.
```
$ echo "version" | nc localhost 11211
VERSION 1.4.14 (Ubuntu)
```

This response breaks the VERSION token parse in this library. The `(Ubuntu)` token should have never been included in the following release:

```
$ dpkg -l | grep ^ii | grep memcache
ii  memcached                           1.4.14-0ubuntu9                  amd64        A high-performance memory object caching system
```

This library is right, and this version of memcached is wrong as per the spec: https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L884

And this PR helps prevent an uncaught exception for when ubuntu's memcached builds decide to violate the protocol.