### PR TITLE
Update io.js build targets for Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ node_js:
   - "0.10"
   - "0.9"
   - "0.8"
-  - "iojs-v1.1"
-  - "iojs-v1.0"
+  - "iojs-v1"
+  - "iojs-v2"
+  - "iojs"
 
 # Create a Travis memcached enabled environment for the test suite to run in and
 # ensure that we test against localhost on Travis-CI.
@@ -33,5 +34,6 @@ matrix:
   allow_failures:
     - node_js: "0.11"
     - node_js: "0.9"
-    - node_js: "iojs-v1.1"
-    - node_js: "iojs-v1.0"
+    - node_js: "iojs-v1"
+    - node_js: "iojs-v2"
+    - node_js: "iojs"


### PR DESCRIPTION
This PR updates the io.js build targets for the Travis CI configuration: `iojs-v1`, `iojs-v2`, and `iojs`.

io.js follows [semver](http://semver.org) which means that patch and minor versions are fully backwards compatible within one major version. I also added the latest `iojs` build target since io.js v3 is right around the corner as per nodejs/io.js#1807.