### PR TITLE
Make it possible to test memcached in a Docker environment

### DIFF
--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -180,12 +180,12 @@ describe('Memcached connections', function () {
   });
   it('should default to port 11211', function(done) {
     // Use an IP without port
-    var server = '127.0.0.1'
+    var server = common.servers.single.split(':')[0]
     , memcached = new Memcached(server);
 
     memcached.get('idontcare', function(err) {
       assert.ifError(err);
-      assert.equal(Object.keys(memcached.connections)[0], '127.0.0.1:11211');
+      assert.equal(Object.keys(memcached.connections)[0], server + ':11211');
       memcached.end();
       done();
     });

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -172,7 +172,7 @@ describe('Memcached connections', function () {
                   memcached.end();
                   done();
                 });
-              }, 150);
+              }, 2500);
             });
           });
       },10);

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -192,7 +192,7 @@ describe('Memcached connections', function () {
   });
   it('should return error on connection timeout', function(done) {
     // Use a non routable IP
-    var server = '10.255.255.255:1234'
+    var server = '10.0.1.1:1234'
     , memcached = new Memcached(server, {
       retries: 0,
       timeout: 100,
@@ -242,7 +242,7 @@ describe('Memcached connections', function () {
     });
   });
   it('should reset failures if all failures do not occur within failuresTimeout ms', function(done) {
-    var server = '10.255.255.255:1234'
+    var server = '10.0.1.1:1234'
     , memcached = new Memcached(server, {
       retries: 0,
       timeout: 10,


### PR DESCRIPTION
There is an ongoing effort in the official Node.JS Build and Test Working Group nodejs/smoke-test#1 to integrate the test suite of many important NPM packages as a part of the official test suite and continuous integration for Node.JS. 

The goal here is to more quickly identify what breaks when, giving core developers important feedback on new features, and package authors an early warning and time to roll out compatible versions with new Node.JS releases when things break. We believe this effort will contribute to make the overall experience of using Node.JS better.

Integrating the test suits for the drivers are particularly challenging since they rely on external dependencies that Node.JS does not control. We are proposing a test infrastructure composed of Docker containers which allows us to create all the different external dependencies in a easy, reproducible, and secure way; you can follow that effort here nodejs/smoke-test#3.

What we need from the drivers is that they 1) do not assume that the test suite is running on the same machine as the services they are dependent upon; 2) that we can in some way configure host and corresponding port variables to point to the external service.

The driver's test suite will run in a container with latest binary of Node.JS installed, and any external dependencies will be linked in as separate containers like this:

```
┌───────────┐   ┌───────────┐
│ memcached │   │ npm test  │
│ ┊┄┄11211┄┄│┄┄┄│┄┄┄┄┄┄┄┄┊  │
│ ┊┄┄11212┄┄│┄┄┄│┄┄┄┄┄┄┄┄┊  │
│ ┊┄┄11213┄┄│┄┄┄│┄┄┄┄┄┄┄┄┊  │
└───────────┘   └───────────┘
[172.17.0.xx]   [172.17.0.yy]
```

I have made three modifications to the test suite to get it working with the Docker setup explained above:
1. Increased timeout for one test since it was failing consistently in the Docker environment (26ab037).
2. Use the known IP address from `common.servers.single` where applicable (1aa225d).
3. Use a routable IP address to prevent `ENETUNREACH` error when testing for connection failures / timeout (3d83a35).
