### PR TITLE
Fixes a SERVER_ERROR when value length is just under the max value length

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -913,7 +913,7 @@ Client.config = {
     value = Utils.escapeValue(value);
 
     length = Buffer.byteLength(value);
-    if (length > this.maxValue) {
+    if (length + fullkey.length + 71 > this.maxValue) {
       return privates.errorResponse(new Error('The length of the value is greater than ' + this.maxValue), callback);
     }
 

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -625,4 +625,28 @@ describe("Memcached GET SET", function() {
       done();
     });
   });
+
+  /**
+   * Set value size just under maximum amount of data (1MB),
+   * should trigger error, not crash. The actual value size to trigger the
+   * error should be value length + key length + length of metadata stored with the
+   * key value pair.
+   */
+  it("set value length just under maximum data and check for correct error handling", function(done) {
+    var memcached = new Memcached(common.servers.single)
+      , message = new Array(32767).join('ThisIsMyTestMessageForThisData32')
+      , testnr = ++global.testnumbers
+      , callbacks = 0;
+    //Length of message is 1048512
+    memcached.set("test:" + testnr, message, 1000, function(error, ok){
+      ++callbacks;
+
+      assert.equal(error, 'Error: The length of the value is greater than 1048576');
+      ok.should.be.false;
+
+      memcached.end(); // close connections
+      assert.equal(callbacks, 1);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
There is a small window of value size just under the max value size that causes a SERVER_ERROR. That window is the key length + the length of meta data stored with the key value pair. When the value size is over the max value length, the driver nicely throws an error back to the client without causing the SERVER_ERROR. This closes that small window that is left. 

I hardcoded in the size of the metadata that I found on my system but I am not sure that is correct for all systems. The places where I found the meta data length mentioned cited a shorter length for most systems so hopefully this takes care of those systems as well with only a few bytes of unusable space.