### PR TITLE
[fix] Fix connection leak when no port is given.

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -118,6 +118,11 @@ Client.config = {
   // Creates or generates a new connection for the give server, the callback
   // will receive the connection if the operation was successful
   memcached.connect = function connect(server, callback) {
+    // Default port to 11211
+    if(!server.match(/(.+):(\d+)$/)) {
+        server = server + ':11211';
+    }
+    
     // server is dead, bail out
     if (server in this.issues && this.issues[server].failed) {
         return callback(false, false);
@@ -129,12 +134,6 @@ Client.config = {
     }
 
     // No connection factory created yet, so we must build one
-
-    // Default port to 11211
-    if(!server.match(/(.+):(\d+)$/)) {
-        server = server + ':11211';
-    }
-
     var serverTokens = server[0] === '/'
         ? server
         : /(.*):(\d+){1,}$/.exec(server).reverse()

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -190,6 +190,23 @@ describe('Memcached connections', function () {
       done();
     });
   });
+  it('should not create multiple connections with no port', function(done) {
+    // Use an IP without port
+    var server = '127.0.0.1'
+    , memcached = new Memcached(server)
+    , conn;
+
+    memcached.get('idontcare', function(err) {
+      assert.ifError(err);
+      conn = memcached.connections['127.0.0.1:11211'];
+      memcached.get('idontcare', function(err) {
+        assert.ifError(err);
+        assert.equal(memcached.connections['127.0.0.1:11211'], conn);
+        memcached.end();
+        done();
+      });
+    });
+  });
   it('should return error on connection timeout', function(done) {
     // Use a non routable IP
     var server = '10.255.255.255:1234'


### PR DESCRIPTION
This commit fixes a connection leak which occurs when no port is
supplied for the memcached server. Since the check for an existing
connection happens before the port is appended, new calls to
`connect` won't pick up the existing connection, and add the new
one with the port.

As is, the current behavior when just passing a host without a port is 
to continually  create new connections, since `this.connections` gets 
stored with the full address.
