### PR TITLE
Add memcached.enabled (for issue #291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Memcached server uses the same properties:
  that are removed from the consistent hashing scheme.
 * `keyCompression`: *true*, whether to use `md5` as hashing scheme when keys exceed `maxKeySize`.
 * `idle`: *5000*, the idle timeout for the connections.
+* `enabled`: *true*, it can be set to `false` bypass the usage of the memcached server. In this
+ case all callbacks will return error `ENOTENABLED`, but won't hang.
 
 Example usage:
 

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -21,6 +21,11 @@ var HashRing = require('hashring')
 var curry = Utils.curry;
 
 /**
+ * Constants
+ */
+var ERROR_NOT_ENABLED = 'ENOTENABLED';
+
+/**
  * Constructs a new memcached client
  *
  * @constructor
@@ -88,7 +93,7 @@ Client.config = {
   , reconnect: 18000000     // if dead, attempt reconnect each xx ms
   , timeout: 5000           // after x ms the server should send a timeout if we can't connect
   , failures: 5             // Number of times a server can have an issue before marked dead
-  , failuresTimeout: 300000   // Time after which `failures` will be reset to original value, since last failure
+  , failuresTimeout: 300000 // Time after which `failures` will be reset to original value, since last failure
   , retry: 30000            // When a server has an error, wait this amount of time before retrying
   , idle: 5000              // Remove connection from pool when no I/O after `idle` ms
   , remove: false           // remove server if dead if false, we will attempt to reconnect
@@ -96,6 +101,8 @@ Client.config = {
   , keyCompression: true    // compress keys if they are to large (md5)
   , namespace: ''           // sentinel to prepend to all memcache keys for namespacing the entries
   , debug: false            // Output the commands and responses
+
+  , enabled: true           // Enable or disable the memcached usage
 };
 
 // There some functions we don't want users to touch so we scope them
@@ -810,6 +817,11 @@ Client.config = {
 
   // This is where the actual Memcached API layer begins:
   memcached.touch = function touch(key, lifetime, callback) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var fullkey = this.namespace + key;
     this.command(function touchCommand() {
       return {
@@ -824,6 +836,11 @@ Client.config = {
   };
 
   memcached.get = function get(key, callback) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     if (Array.isArray(key)) return this.getMulti.apply(this, arguments);
 
     var fullkey = this.namespace + key;
@@ -841,6 +858,11 @@ Client.config = {
   // the difference between get and gets is that gets, also returns a cas value
   // and gets doesn't support multi-gets at this moment.
   memcached.gets = function get(key, callback) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var fullkey = this.namespace + key;
     this.command(function getCommand(noreply) {
       return {
@@ -855,6 +877,11 @@ Client.config = {
 
   // Handles get's with multiple keys
   memcached.getMulti = function getMulti(keys, callback) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var memcached = this
       , responses = {}
       , errors = []
@@ -910,6 +937,11 @@ Client.config = {
   // do not require a lifetime and a flag, but the memcached server is smart
   // enough to ignore those.
   privates.setters = function setters(type, validate, key, value, lifetime, callback, cas) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var fullkey = this.namespace + key;
     var flag = 0
       , valuetype = typeof value
@@ -1033,6 +1065,11 @@ Client.config = {
 
   // Small handler for incr and decr's
   privates.incrdecr = function incrdecr(type, key, value, callback) {
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var fullkey = this.namespace + key;
     this.command(function incredecrCommand(noreply) {
       return {
@@ -1058,6 +1095,11 @@ Client.config = {
 
   // Deletes the keys from the servers
   memcached.del = function del(key, callback){
+    if(!this.enabled) {
+      callback && callback(ERROR_NOT_ENABLED);
+      return;
+    }
+
     var fullkey = this.namespace + key;
     this.command(function deleteCommand(noreply) {
       return {

--- a/test/memcached-disabled.js
+++ b/test/memcached-disabled.js
@@ -1,0 +1,94 @@
+var assert = require('assert')
+  , fs = require('fs')
+  , common = require('./common')
+  , Memcached = require('../')
+  , ERROR_NOT_ENABLED = 'ENOTENABLED';  // defined in memcached.js constants
+
+global.testnumbers = global.testnumbers || +(Math.random(10) * 1000000).toFixed();
+
+/**
+ * Test all public functions to act properly with memcached.enabled = false
+ */
+describe("Memcached disabled", function() {
+  /**
+   * Check that changing the memcached.enabled option has effect in real time
+   */
+  it("memcached.enabled value change", function(done) {
+    function test() {
+      var enabled = memcached.enabled;
+      memcached.get(testnr++, function(error, data) {
+        if(enabled) {
+          assert.ok(!error);
+        } else {
+          assert.equal(ERROR_NOT_ENABLED, error);
+        }
+
+        if(++callbacks === totalCalls) {
+          done();
+        }
+      });
+    }
+
+    var memcached = new Memcached(common.servers.single)
+      , testnr = ++global.testnumbers
+      , callbacks = 0
+      , totalCalls = 3
+      , i = totalCalls;
+
+    while(i--) {
+      test();
+      memcached.enabled = !memcached.enabled;
+    }
+  });
+
+  /**
+   * Instance can be created specifying the { enabled: false } option directly
+   * All public methods should invoke the callback with error
+   */
+  it(ERROR_NOT_ENABLED + " error if enabled is false", function(done) {
+    function test(fn, ary, done) {
+      function callback(error, ok) {
+        ++callbacks;
+        assert.equal(ERROR_NOT_ENABLED, error);
+        assert.equal(callbacks, 1);
+        done();
+      }
+
+      var memcached = new Memcached(common.servers.single, { enabled: false })
+        , callbacks = 0
+        , args = [++global.testnumbers, 10, 10, 'casStringValue'];
+
+      args.splice(ary);
+      args[ary-1] = callback;
+
+      memcached[fn].apply(memcached, args);
+    }
+
+    var fn2 = 'get,gets,getMulti,del'.split(',')
+      , fn3 = 'touch,append,prepend,incr,decr'.split(',')
+      , fn4 = 'set,replace,add'.split(',')
+      , fn5 = 'cas'.split(',')
+      , called = 0
+      , total = fn2.length + fn3.length + fn4.length + fn5.length;
+
+    function callback() {
+      ++called;
+      if(called === total) {
+        done();
+      }
+    }
+
+    for(var i=0; i<fn2.length; i++) {
+      test(fn2[i], 2, callback);
+    }
+    for(var i=0; i<fn3.length; i++) {
+      test(fn3[i], 3, callback);
+    }
+    for(var i=0; i<fn4.length; i++) {
+      test(fn4[i], 4, callback);
+    }
+    for(var i=0; i<fn5.length; i++) {
+      test(fn5[i], 5, callback);
+    }
+  });
+});


### PR DESCRIPTION
Implements a new option (`enabled`)
By default to `true`, it doesn't change the current behavior. If set to `false`, bypass the memcached calls, invoking the error callback with `ENOTENABLED` value.
This allows to test the same code with/without usage of memcached.

It also allows to manage errors in case of server failure to avoid waiting for a callback that won't come.

The usage is as easy as:
```javascript
var memcached = new Memcached(server, { enabled: false });
```
or in real time:
```javascript
memcached.on('issue', function() {
    memcached.enabled = false;
}
memcached.on('reconnect', function() {
    memcached.enabled = true;
}
memcached.get('key', function(error, data) {
    // now if the server is down this function should be called with error ENOTENABLED instead of hanging
});
```
