### PR TITLE
memcached.setMulti

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ memcached.getMulti(['foo', 'bar'], function (err, data) {
 memcached.set('foo', 'bar', 10, function (err) { /* stuff */ });
 ```
 
+**memcached.setMulti** Stores a bunch of values in Memcached.
+
+* `values`: **Object** list of values to store as `{ key: value }`
+* `lifetime`: **Number**, how long the data needs to be stored measured in `seconds` (same for all values)
+* `callback`: **Function** the callback
+
+```js
+var values = {
+  key1: 'text',
+  key2: 1234,
+  key3: { a:1, b:2, c:3 }
+};
+memcached.setMulti(values, 10, function (err) { /* stuff */ });
+```
+
 **memcached.replace** Replaces the value in memcached.
 
 * `key`: **String** the name of the key

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -951,6 +951,39 @@ Client.config = {
     });
   };
 
+  memcached.setMulti = function(values, lifetime, callback) {
+    function exec(key) {
+      self.set(key, values[key], lifetime, function(error, ok) {
+        if(failed) {
+          return;
+        }
+
+        if(error) {
+          failed = true;
+          console.log(error);
+          callback(error);
+          return;
+        }
+
+        results[key] = ok;
+        if(++cb === total) {
+          callback(undefined, results);
+        }
+      });
+    }
+
+    var keys = Object.keys(values)
+      , total = keys.length
+      , cb = 0
+      , failed = false
+      , results = {}
+      , self = this;
+
+    for(var i = 0; i < total; i++) {
+      exec(keys[i]);
+    }
+  };
+
   // Curry the function and so we can tell the type our private set function
   memcached.set = curry(undefined, privates.setters
     , 'set'

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -13,7 +13,7 @@ global.testnumbers = global.testnumbers || +(Math.random(10) * 1000000).toFixed(
  * Expresso test suite for all `get` related
  * memcached commands
  */
-describe.only("Memcached GET SET", function() {
+describe("Memcached GET SET", function() {
   /**
    * Make sure that the string that we send to the server is correctly
    * stored and retrieved. We will be storing random strings to ensure

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -13,7 +13,7 @@ global.testnumbers = global.testnumbers || +(Math.random(10) * 1000000).toFixed(
  * Expresso test suite for all `get` related
  * memcached commands
  */
-describe("Memcached GET SET", function() {
+describe.only("Memcached GET SET", function() {
   /**
    * Make sure that the string that we send to the server is correctly
    * stored and retrieved. We will be storing random strings to ensure
@@ -623,6 +623,46 @@ describe("Memcached GET SET", function() {
       memcached.end();
       assert.equal(callbacks, 1);
       done();
+    });
+  });
+
+  /**
+   * Make sure that all the specified values are set properly.
+   * The callback should be called only once after everything is set.
+   * Since it's just a wrapper for set, just check that the values are correct.
+   */
+  it("multi set", function(done) {
+    var memcached = new Memcached(common.servers.single)
+      , testnr = global.testnumbers
+      , callbacks = 0
+      , values = {}
+      , list;
+
+    values["test:" + (++testnr)] = 'text';
+    values["test:" + (++testnr)] = 1234;
+    values["test:" + (++testnr)] = { a: 1, b: 2 };
+    list = Object.keys(values);
+
+    memcached.setMulti(values, 1000, function(error, ok) {
+      ++callbacks;
+      assert.equal(callbacks, 1);
+      assert.ok(!error);
+
+      var okList = Object.keys(ok);
+      for(var i = 0; i < okList.length; i++) {
+        assert.ok(ok[okList[i]]);
+      }
+
+      memcached.getMulti(list, function(error, data) {
+        ++callbacks;
+
+        assert.ok(!error);
+        assert.deepEqual(data, values);
+
+        memcached.end(); // close connections
+        assert.equal(callbacks, 2);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
(issue #290)
Added setMulti to work as getMulti, but just as a wrapper of set with multiple calls.
This can be improved using direct server commands in the future.
