### PR TITLE
Prevent misuse of memcached client constructor

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -29,6 +29,11 @@ var curry = Utils.curry;
  * @api public
  */
 function Client (args, options) {
+  // Ensure Client instantiated with 'new'
+  if (this === undefined) {
+    return new Client(args, options);
+  }
+
   var servers = []
     , weights = {}
     , regular = 'localhost:11211'

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -30,7 +30,7 @@ var curry = Utils.curry;
  */
 function Client (args, options) {
   // Ensure Client instantiated with 'new'
-  if (this === undefined) {
+  if (!(this instanceof Client)) {
     return new Client(args, options);
   }
 

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -17,6 +17,11 @@ global.testnumbers = global.testnumbers || +(Math.random(10) * 1000000).toFixed(
  * Test connection issues
  */
 describe('Memcached connections', function () {
+  it('should instantiate client when not called with new', function(done) {
+    var memcached = Memcached('127.0.0.1:1234', {});
+    memcached.end();
+    done();
+  });
   it('should call the callback only once if theres an error', function (done) {
     var memcached = new Memcached('127.0.1:1234', { retries: 3 })
       , calls = 0;


### PR DESCRIPTION
Add check for when 'this' is undefined which (in strict mode)
signals that the user called the function directly instead of
using the 'new' operator. In this case, return a newly
instantiated client using the same parameters.

This prevents indescriptive errors when applying the global
config to the newly instantiated client when the user forgets
to instantiate the client with 'new' operator.