### PR TITLE
Support namespaces on CAS operations

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -846,11 +846,24 @@ Client.config = {
   // the difference between get and gets is that gets, also returns a cas value
   // and gets doesn't support multi-gets at this moment.
   memcached.gets = function get(key, callback) {
-    var fullkey = this.namespace + key;
+    var memcached = this
+      , fullkey = this.namespace + key;
+
+    function handle(err, results) {
+      if (err) {
+        return callback(err);
+      }
+
+      var response = {};
+      response.cas = results.cas;
+      response[fullkey.replace(memcached.namespace, '')] = results[fullkey];
+      callback(err, response);
+    }
+
     this.command(function getCommand(noreply) {
       return {
           key: fullkey
-        , callback: callback
+        , callback: handle
         , validate: [['key', String], ['callback', Function]]
         , type: 'gets'
         , command: 'gets ' + fullkey


### PR DESCRIPTION
I was doing some work on atomic updates to Memcache using CAS, and ran it an issue when you have namespaces enabled in your Memcached-client: The namespace would still be present in the object that is returned.

So when you have a namespace `foo:` and do a  `client.gets('bar', function(err, res) { ... })` then the response-object contains `{cas: ?, 'foo:bar': ?}` instead of the expected `{cas: ?, bar: ?}`.

I've updated the namespace tests to also included a successful CAS-write with a namespace and added a handle-function to the `gets`-function that strips the namespace off of the full key.

Kind regards
Morten