### PR TITLE
add error handler for spawning ping

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,6 +13,11 @@ function ping (host, callback) {
   var arg = isWin ? '-n' : '-c';
   var pong = spawn('ping', [arg, '3', host]); // only ping 3 times
 
+  pong.on('error', function onerror (error) {
+    callback(error, false);
+    pong.kill();
+  });
+
   pong.stdout.on('data', function stdoutdata (data) {
     callback(false, data.toString().split('\n')[0].substr(14));
     pong.kill();


### PR DESCRIPTION
We run restify inside of a `nodesource/xenial:6.3.1` docker container.
This container did not have `ping` installed. So when connections would occasionally fail, the spawn error would get bubbled up to the restify exception handler (they use [domains](https://nodejs.org/docs/latest-v6.x/api/domain.html)).
This would cause our request to fail and return an error for no reason.

This PR handles those spawn errors, which prevents it from being bubbled up.