### PR TITLE
Handling error during JSON parsing

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -516,8 +516,15 @@ Client.config = {
 
       switch (flag) {
         case FLAG_JSON:
-          dataSet = JSON.parse(dataSet);
-          break;
+            try {
+                dataSet = JSON.parse(dataSet);
+                break;
+            } catch (err) {
+                dataSet = null;
+                err.push(new Error('error during JSON parsing'));
+                break;
+            }
+          
         case FLAG_NUMERIC:
           dataSet = +dataSet;
           break;


### PR DESCRIPTION
Fix for a scenario where the memcache JSON data was stored in a improper format resulting in an error shown as below which invokes an uncaught exception. This can be prevented by the given solution.
SyntaxError: Unexpected token x in JSON at position 0
 at JSON.parse (<anonymous>)
 at Socket.value (/memcached/lib/memcached.js:514:26)
 at Client.rawDataReceived (/memcached/lib/memcached.js:744:51)
 at Client.BufferBuffer (/memcached/lib/memcached.js:678:12)
 at Socket.bowlofcurry (/memcached/lib/utils.js:126:15)
 at emitOne (events.js:115:13)
 at Socket.emit (events.js:210:7)
 at addChunk (_stream_readable.js:250:12)
 at readableAddChunk (_stream_readable.js:233:13)
 at Socket.Readable.push (_stream_readable.js:195:10)
 at TCP.onread (net.js:586:20)
