### PR TITLE
fix getMulti

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -865,6 +865,10 @@ Client.config = {
       , errors = []
       , calls;
 
+    if (keys.length === 0) {
+      callback(undefined, {});
+    }
+
     if (memcached.namespace.length) keys = keys.map(function compile(key){
       return memcached.namespace + key;
     });

--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -866,7 +866,7 @@ Client.config = {
       , calls;
 
     if (keys.length === 0) {
-      callback(undefined, {});
+      return callback(undefined, {});
     }
 
     if (memcached.namespace.length) keys = keys.map(function compile(key){

--- a/test/memcached-get-set.test.js
+++ b/test/memcached-get-set.test.js
@@ -625,4 +625,17 @@ describe("Memcached GET SET", function() {
       done();
     });
   });
+
+  /*
+    Make sure that getMulti works with empty keys
+  */
+  it("make sure you can getMulti really long keys", function (done) {
+    var memcached = new Memcached(common.servers.single);
+
+    memcached.getMulti([], function (error, ok) {
+      assert.deepEqual(ok, {});
+      memcached.end();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Changes

**Current Behavior**
if **getMulti** called with empty **keys([])** it just "hangs". doesn't callback.

**New behavior**
if **getMulti** called with empty **keys([])** it immediately callback empty response ({})  