### PR TITLE
Don't append port for unix socket

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -124,7 +124,7 @@ Client.config = {
   // will receive the connection if the operation was successful
   memcached.connect = function connect(server, callback) {
     // Default port to 11211
-    if(!server.match(/(.+):(\d+)$/)) {
+    if (!server.match(/(.+):(\d+)$/) && !server.match(/\/memcached\.sock$/i)) {
         server = server + ':11211';
     }
 


### PR DESCRIPTION
By appending default port `11211` to unix socket connection we can't connect to memcached server.