### PR TITLE
test case fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # Ensure that we only run CI test on the Node.js enabled servers.
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
+  - "8"
 
 # Create a Travis memcached enabled environment for the test suite to run in and
 # ensure that we test against localhost on Travis-CI.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,3 @@ before_script:
   - memcached -p 11212 -d
   - memcached -p 11213 -d
 
-# Fix broken builds caused by packages using the carrot semver bullshit.
-before_install:
-  - "npm install -g npm@2.1.x"
-

--- a/README.md
+++ b/README.md
@@ -457,6 +457,12 @@ For compatibility with other [libmemcached](http://libmemcached.org/Clients.html
 
 Due to client dependent type flags it is unlikely that any types other than `string` will work.
 
+# Test
+You may encounter several problems when run the test. Be sure you already made these preparations:
+1. Start the `memcached` service. (If in Mac env, you can install it via homebrew, and `brew services start memcached`)
+2. Start 3 memcached servers at port 11211, 11212, 11213. (You first service will start at default port 11211, so you need to start 2 other servers manually. `memcached -p 11212 -d`, `memcached -p 11213 -d`)
+3. Run `export MEMCACHED__HOST=localhost` in your terminal. (This will make sure that the test case use `localhost` as your memcached server IP address other than it's default IP)
+
 # Contributors
 
 This project wouldn't be possible without the hard work of our amazing

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "pre-commit": "*"
   },
   "scripts": {
-    "test": "mocha $(find test -name '*.test.js')"
+    "test": "mocha $(find test -name '*.test.js') --exit"
   }
 }

--- a/test/memcached-connections.test.js
+++ b/test/memcached-connections.test.js
@@ -214,7 +214,8 @@ describe('Memcached connections', function () {
   });
   it('should return error on connection timeout', function(done) {
     // Use a non routable IP
-    var server = '10.255.255.255:1234'
+    // why this IP: https://en.wikipedia.org/wiki/Reserved_IP_addresses#cite_note-rfc5737-5
+    var server = '203.0.113.255:1234'
     , memcached = new Memcached(server, {
       retries: 0,
       timeout: 100,
@@ -264,7 +265,7 @@ describe('Memcached connections', function () {
     });
   });
   it('should reset failures if all failures do not occur within failuresTimeout ms', function(done) {
-    var server = '10.255.255.255:1234'
+    var server = '203.0.113.255:1234'
     , memcached = new Memcached(server, {
       retries: 0,
       timeout: 10,


### PR DESCRIPTION
1. Use `203.0.113.255` instead of `10.255.255.255`. According to [Reserved_IP_addresses](https://en.wikipedia.org/wiki/Reserved_IP_addresses#cite_note-rfc5737-5), `203.0.113.255` is for test. But `10.255.255.255` can be used by company's LAN, the gateway.
2. fix #328 for now 
3. update travis node version (because node v0.x.x) don't support `const` which mocha v5 used this  
4. add readme about how to run test