### PR TITLE
Replaced ping-based healthcheck with net.createConnection

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,31 +1,23 @@
 "use strict";
 
 var EventEmitter = require('events').EventEmitter
-  , spawn = require('child_process').spawn
+  , net = require('net')
   , Utils = require('./utils')
   , util = require('util');
 
 exports.IssueLog = IssueLog;         // connection issue handling
-exports.Available = ping;            // connection availablity
 
-function ping (host, callback) {
-  var isWin = process.platform.indexOf('win') === 0; // win32 or win64
-  var arg = isWin ? '-n' : '-c';
-  var pong = spawn('ping', [arg, '3', host]); // only ping 3 times
-
-  pong.on('error', function onerror (error) {
-    callback(error, false);
-    pong.kill();
+function ping (host, port, timeout, callback) {
+  var socket = net.createConnection({ port: port, host: host }, function (err) {
+    callback(err);
+    socket.end();
   });
 
-  pong.stdout.on('data', function stdoutdata (data) {
-    callback(false, data.toString().split('\n')[0].substr(14));
-    pong.kill();
-  });
+  socket.setTimeout(timeout);
 
-  pong.stderr.on('data', function stderrdata (data) {
-    callback(new Error(data.toString().split('\n')[0].substr(14)), false);
-    pong.kill();
+  socket.on('error', function (err) {
+    callback(err);
+    socket.end();
   });
 }
 
@@ -115,7 +107,7 @@ issues.attemptReconnect = function attemptReconnect () {
   this.emit('reconnecting', this.details);
 
   // Ping the server
-  ping(this.tokens[1], function pingpong (err) {
+  ping(this.tokens[1], this.tokens[0] || 11211, this.config.maxTimeout || 100, function pingpong (err) {
     // still no access to the server
     if (err) {
       issue.messages.push(err.message || 'No message specified');


### PR DESCRIPTION
Older ping-based healthcheck had a bunch of problems:
* Doesn't work in ipv6-only environment (because of calling `ping`, not
`ping6`).
* Doesn't work if ICMP is blocked, but TCP is not
* Doesn't work as expected if TCP on this exact port is firewalled out. 
* Uses a lot of CPU on process spawning, may cause DoS in clusters with
large number of worker processes. 

Healthcheck with net.createConnection seems to be a much simpler and
more robust alternative

Two test were needed changing:
* One was implicitly tied to ping interval; ECONNREFUSED was thrown faster,
I've tuned reconnect timeout in test
* Another one actually relied upon one of aforementioned problems:
setting up server at 127.0.0.1:1234 would mean server is available to
ping, but not to TCP connection. In that test, I've used
net.listen to actually listen for connections on socket