### PR TITLE
Require mocha before 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "jackpot": ">=0.0.6"
   },
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "<8.0.0",
     "should": "*",
     "pre-commit": "*"
   },


### PR DESCRIPTION
mocha 8.x removed support for mocha.opts, and had been announcing that through a deprecation warning
before:
~~~~
(node:200058) DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.
~~~~