### PR TITLE
Add modula distribution

### DIFF
--- a/lib/memcached.js
+++ b/lib/memcached.js
@@ -4,7 +4,8 @@
  * Node's native modules
  */
 var Stream = require('net').Stream
-  , Socket = require('net').Socket;
+  , Socket = require('net').Socket
+  , crypto = require('crypto');
 
 /**
  * External or custom modules
@@ -64,11 +65,13 @@ function Client (args, options) {
   Utils.merge(this, options);
 
   this.servers = servers;
-  var compatibility = this.compatibility || this.compatiblity;
-  this.HashRing = new HashRing(args, this.algorithm, {
-    'compatibility': compatibility,
-    'default port': compatibility === 'ketama' ? 11211 : null
-  });
+  if (!this.modula) {
+    var compatibility = this.compatibility || this.compatiblity;
+    this.HashRing = new HashRing(args, this.algorithm, {
+      'compatibility': compatibility,
+      'default port': compatibility === 'ketama' ? 11211 : null
+    });
+  }
   this.connections = {};
   this.issues = [];
 }
@@ -82,6 +85,7 @@ Client.config = {
   , maxQueueSize: -1
   , algorithm: 'md5'        // hashing algorithm that is used for key mapping
   , compatibility: 'ketama' // hashring compatibility
+  , modula: false           // use modula distribution instead of hashring
   , encoding: 'utf8'        // data encoding, if you use another encoding such as 'binary'
 
   , poolSize: 10            // maximal parallel connections
@@ -240,9 +244,12 @@ Client.config = {
     // or just gives all servers if we don't have keys
     if (keys) {
       keys.forEach(function fetchMultipleServers(key) {
-        var server = memcached.servers.length === 1
-          ? memcached.servers[0]
-          : memcached.HashRing.get(key);
+        var server = memcached.servers[0];
+
+        if (memcached.servers.length > 1) {
+          server = memcached.modula ?
+            memcached.getServerByModulaDistribution(key) : memcached.HashRing.get(key);
+        }
 
         if (map[server]){
           map[server].push(key);
@@ -296,11 +303,15 @@ Client.config = {
       if (this.servers.length === 1) {
         server = this.servers[0];
       } else {
-        if (redundancy && queryRedundancy) {
-          redundancy = this.HashRing.range(query.key, (this.redundancy + 1), true);
-          server = redundancy.shift();
+        if (this.modula) {
+          server = this.getServerByModulaDistribution(query.key);
         } else {
-          server = this.HashRing.get(query.key);
+          if (redundancy && queryRedundancy) {
+            redundancy = this.HashRing.range(query.key, (this.redundancy + 1), true);
+            server = redundancy.shift();
+          } else {
+            server = this.HashRing.get(query.key);
+          }
         }
       }
     }
@@ -413,13 +424,15 @@ Client.config = {
             memcached.emit('remove', details);
             memcached.connections[server].end();
 
-            if (this.failOverServers && this.failOverServers.length) {
-              memcached.HashRing.swap(server, this.failOverServers.shift());
-            } else {
-              memcached.HashRing.remove(server);
-              memcached.emit('failure', details);
+            if (!this.modula) {
+              if (this.failOverServers && this.failOverServers.length) {
+                memcached.HashRing.swap(server, this.failOverServers.shift());
+              } else {
+                memcached.HashRing.remove(server);
+                memcached.emit('failure', details);
+              }
             }
-          }
+        }
       });
 
       // bumpt the event listener limit
@@ -1149,6 +1162,18 @@ Client.config = {
       };
     }, server);
   };
+
+  memcached.getServerByModulaDistribution = function modulaDistribution(key) {
+    var hashValue;
+
+    if ('function' === typeof this.algorithm) {
+      hashValue = this.algorithm(key);
+    } else {
+      hashValue = crypto.createHash(this.algorithm).update(key).digest().readUint32BE();
+    }
+
+    return this.servers[hashValue % this.servers.length];
+  }
 })(Client);
 
 module.exports = Client;


### PR DESCRIPTION
Hi and thanks for all the effort you put in this library !

We needed modula distribution at my company to be compatible with the default PHP's memcached client config (https://www.php.net/manual/en/memcached.constants.php).

Modula distribution is nothing complicated as it does `this.servers[keyHashValue % this.servers.length]` to pick the correct server to query. I just disabled hashring if new option `modula` is set to true and use modula distribution instead.

This is related to https://github.com/3rd-Eden/memcached/issues/311 but I think more companies could face/are facing this issue when dealing with a legacy PHP stack.

Any feedback is welcome !